### PR TITLE
Audit at 2021-06-08

### DIFF
--- a/meta-token/src/internal.rs
+++ b/meta-token/src/internal.rs
@@ -37,6 +37,10 @@ impl Contract {
     pub fn internal_unwrap_balance_of(&self, account_id: &AccountId) -> Balance {
         match self.accounts.get(&account_id) {
             Some(balance) => balance,
+            // Q: This makes the contract vulnerable to the sybil attack on storage.
+            // Since `ft_transfer` is cheaper than storage for 1 account, you can send
+            // 1 token to a ton randomly generated accounts and it will require 125 bytes per
+            // such account. So it would require 800 transactions to block 1 NEAR of the account.
             None => 0,
         }
     }

--- a/meta-token/src/lib.rs
+++ b/meta-token/src/lib.rs
@@ -120,6 +120,7 @@ impl Contract {
     }
 }
 
+// Q: Is ignoring storage costs the only reason for the reimplementation?
 #[near_bindgen]
 impl FungibleTokenCore for Contract {
     #[payable]

--- a/metapool/src/internal.rs
+++ b/metapool/src/internal.rs
@@ -511,6 +511,8 @@ impl MetaPool {
             // if the pool is not busy, has stake
             if !sp.busy_lock && sp.staked > 0 {
                 //if has not unstaked balance waiting for withdrawal, or wait started in this same epoch (no harm in unstaking more)
+                // TODO: Unstaking in the same epoch is only an issue, if you hit the last block of the epoch.
+                //    In this case the receipt may be executed at the next epoch.
                 if sp.wait_period_ended() || sp.unstk_req_epoch_height == env::epoch_height() {
                     // if this pool has an unbalance requiring un-staking
                     let should_have = apply_pct(sp.weight_basis_points, self.total_for_staking);

--- a/metapool/src/owner.rs
+++ b/metapool/src/owner.rs
@@ -75,6 +75,10 @@ impl MetaPool {
         if sp.busy_lock {
             panic!("sp is busy")
         }
+        // TODO: If `weight_basis_points` is invalid, the owner can break the contract.
+        //    Ideally, the owner shouldn't have any power to break the contract and instead should
+        //    should only manipulate the pools with verification that it's a real pool, but it's
+        //    difficult to enforce.
         sp.weight_basis_points = weight_basis_points;
     }
 


### PR DESCRIPTION
I haven't looked:
- `fungible_token_standard.rs`
- `validator_loans.rs`
- `migrations.rs`

Comments inline. Major concerns:
- META withdrawal can be called multiple times before the value is updated.
- The contract can potentially be locked if something with the callback fails. This can be relaxed using the following pattern invented by @oysterpack. You have schedule 3 promises where one depends on the previous one, let's call them: `remote`, `then`, `finally`. Since both `then` and `finally` promises are executed on your contract you guarantee the correctness of the data that you pass there. But you also may let `then` to fail. Now in the `finally` promise you unlock the contract and check that `then` promise succeeded, but if `then` failed, you rollback the state that you did in the original call.
- I haven't looked too closely at `contract_account_balance`, but `transfer_extra_balance_accumulated` may actually be unsafe if `contract_account_balance` is incorrectly calculated.
- Border blocks cases for the epoch may cause some issues. If some operation of this contract called in the last block of the epoch, then the execution on the staking pool may happen in the next epoch. This may lead to attempt at earlier withdrawal. 
- Add liquidity may be potentially wrapped into a sandwich by a malicious validator resulting in getting liquidity at the unfair terms. Or the pool may shift before the liquidity is added. Ideally you want to add some slippage limit on min LP shares amount received.
